### PR TITLE
proxy server configuration via env

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,6 +209,19 @@ Please help us to grow this list of supported banks:
 * Sparkasse KölnBonn
 * Commerz Bank
 
+
+## Development
+
+For development purposes, you may want to use a proxy server in order to have a convienent look into request and response data.
+To do so, it's sufficient to define `http_proxy` in your environment.
+Also you may want to disable SSL verification - simply set `EPICS_VERIFY_SSL` to `"false"`.
+
+For example:
+```
+http_proxy=localhost:8080
+EPICS_VERIFY_SSL=false
+```
+
 ## Links
 
 * [ebics.de](http://www.ebics.de/)

--- a/lib/epics/client.rb
+++ b/lib/epics/client.rb
@@ -247,7 +247,7 @@ class Epics::Client
   end
 
   def use_proxy?
-    ENV['EPICS_HTTP_PROXY'].present?
+    !ENV['EPICS_HTTP_PROXY'].nil?
   end
 
   def http_proxy

--- a/lib/epics/client.rb
+++ b/lib/epics/client.rb
@@ -207,7 +207,6 @@ class Epics::Client
       faraday.use Epics::ParseEbics, { client: self}
       # faraday.response :logger                  # log requests to STDOUT
       faraday.adapter  Faraday.default_adapter  # make requests with Net::HTTP
-      faraday.proxy http_proxy if use_proxy?
     end
   end
 
@@ -244,14 +243,6 @@ class Epics::Client
   def setup_cipher(method, passphrase, salt)
     cipher.send(method)
     cipher.key = OpenSSL::PKCS5.pbkdf2_hmac_sha1(passphrase, salt, 1, cipher.key_len)
-  end
-
-  def use_proxy?
-    !ENV['EPICS_HTTP_PROXY'].nil?
-  end
-
-  def http_proxy
-    ENV['EPICS_HTTP_PROXY']
   end
 
   def verify_ssl?

--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -24,19 +24,7 @@ RSpec.describe Epics::Client do
 
   context 'environment settings' do
     before(:each) do
-      ENV.delete('EPICS_HTTP_PROXY')
       ENV.delete('EPICS_VERIFY_SSL')
-    end
-
-    describe '#use_proxy?' do
-      it 'returns false if there is no configured proxy' do
-        expect(subject.send(:use_proxy?)).to eq false
-      end
-
-      it 'returns true if there is a configured proxy' do
-        ENV['EPICS_HTTP_PROXY'] = 'yourproxy:31337'
-        expect(subject.send(:use_proxy?)).to eq true
-      end
     end
 
     describe '#verify_ssl?' do

--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -22,6 +22,40 @@ RSpec.describe Epics::Client do
 
   end
 
+  context 'environment settings' do
+    before(:each) do
+      ENV.delete('EPICS_HTTP_PROXY')
+      ENV.delete('EPICS_VERIFY_SSL')
+    end
+
+    describe '#use_proxy?' do
+      it 'returns false if there is no configured proxy' do
+        expect(subject.send(:use_proxy?)).to eq false
+      end
+
+      it 'returns true if there is a configured proxy' do
+        ENV['EPICS_HTTP_PROXY'] = 'yourproxy:31337'
+        expect(subject.send(:use_proxy?)).to eq true
+      end
+    end
+
+    describe '#verify_ssl?' do
+      it 'verifies ssl by default' do
+        expect(subject.send(:verify_ssl?)).to eq true
+      end
+
+      it 'verifies ssl if there\'s something strange set to your env' do
+        ENV['EPICS_VERIFY_SSL'] = 'somethingstrange'
+        expect(subject.send(:verify_ssl?)).to eq true
+      end
+
+      it 'skips ssl verification if you want to' do
+        ENV['EPICS_VERIFY_SSL'] = 'false'
+        expect(subject.send(:verify_ssl?)).to eq false
+      end
+    end
+  end
+
   describe '#inspect' do
     it 'will not print the complete object' do
       expect(subject.inspect).to include("@keys=#{subject.keys.keys}")


### PR DESCRIPTION
It's possible to use an HTTP(S)-Proxy with Faraday now. Also, mainly for development purposes, it's possible to skip SSL-verification. Fixes all the invalid certificate errors. :trollface: 
