### PR TITLE
Remove date range requirement for STA orders

### DIFF
--- a/lib/epics/client.rb
+++ b/lib/epics/client.rb
@@ -123,7 +123,7 @@ class Epics::Client
     upload(Epics::CCT, document)
   end
 
-  def STA(from, to)
+  def STA(from = nil, to = nil)
     download(Epics::STA, from, to)
   end
 

--- a/lib/epics/sta.rb
+++ b/lib/epics/sta.rb
@@ -1,10 +1,18 @@
 class Epics::STA < Epics::GenericRequest
   attr_accessor :from, :to
 
-  def initialize(client, from, to)
+  def initialize(client, from = nil, to = nil)
     super(client)
     self.from = from
     self.to = to
+  end
+
+  def date_range
+    if !!from && !!to
+      { "DateRange" => { "Start" => from, "End" => to } }
+    else
+      { :content! => '' }
+    end
   end
 
   def header
@@ -23,12 +31,7 @@ class Epics::STA < Epics::GenericRequest
         "OrderDetails" => {
           "OrderType" => "STA",
           "OrderAttribute" => "DZHNN",
-          "StandardOrderParams" => {
-            "DateRange" => {
-              "Start" => from,
-              "End" => to
-            }
-          }
+          "StandardOrderParams" => date_range
         },
         "BankPubKeyDigests" => {
           "Authentication" => {

--- a/spec/orders/sta_spec.rb
+++ b/spec/orders/sta_spec.rb
@@ -1,17 +1,39 @@
 RSpec.describe Epics::STA do
-
   let(:client) { Epics::Client.new( File.open(File.join( File.dirname(__FILE__), '..', 'fixtures', 'SIZBN001.key')), 'secret' , 'https://194.180.18.30/ebicsweb/ebicsweb', 'SIZBN001', 'EBIX', 'EBICS') }
 
-  subject { described_class.new(client, "2014-09-01", "2014-09-30") }
+  context 'with date range' do
+    subject(:order) { described_class.new(client, "2014-09-01", "2014-09-30") }
 
-  describe '#to_xml' do
-    specify { expect(subject.to_xml).to be_a_valid_ebics_doc }
+    describe '#to_xml' do
+      specify { expect(order.to_xml).to be_a_valid_ebics_doc }
+
+      it 'does includes a date range as standard order parameter' do
+        expect(order.to_xml).to include('<StandardOrderParams><DateRange><Start>2014-09-01</Start><End>2014-09-30</End></DateRange></StandardOrderParams>')
+      end
+    end
+
+    describe '#to_receipt_xml' do
+      before { order.transaction_id = SecureRandom.hex(16) }
+
+      specify { expect(order.to_receipt_xml).to be_a_valid_ebics_doc }
+    end
   end
 
-  describe '#to_receipt_xml' do
-    before { subject.transaction_id = SecureRandom.hex(16) }
+  context 'without date range' do
+    subject(:order) { described_class.new(client) }
 
-    specify { expect(subject.to_receipt_xml).to be_a_valid_ebics_doc }
+    describe '#to_xml' do
+      specify { expect(order.to_xml).to be_a_valid_ebics_doc }
+
+      it 'does not include a standard order parameter' do
+        expect(order.to_xml).to include('<StandardOrderParams/>')
+      end
+    end
+
+    describe '#to_receipt_xml' do
+      before { order.transaction_id = SecureRandom.hex(16) }
+
+      specify { expect(order.to_receipt_xml).to be_a_valid_ebics_doc }
+    end
   end
-
 end


### PR DESCRIPTION
STA orders to not necessarily need a date range. Actually the default should be to not submit it. When requesting without date range, the remote server only returns those orders which have not yet been retrieved. A date range is only needed if already received statements should be fetched again.