### PR TITLE
Do not supply a date range for HAC by default

### DIFF
--- a/lib/epics/client.rb
+++ b/lib/epics/client.rb
@@ -159,7 +159,7 @@ class Epics::Client
     download(Epics::PTK, from, to)
   end
 
-  def HAC(from, to)
+  def HAC(from = nil, to = nil)
     download(Epics::HAC, from, to)
   end
 

--- a/lib/epics/hac.rb
+++ b/lib/epics/hac.rb
@@ -1,10 +1,21 @@
 class Epics::HAC < Epics::GenericRequest
   attr_accessor :from, :to
 
-  def initialize(client, from, to)
+  # By default HAC only returns data for transactions which have not yet been fetched. Therefore,
+  # most applications not not have to specify a date range, but can simply fetch the status and
+  # be done
+  def initialize(client, from = nil, to = nil)
     super(client)
     self.from = from
     self.to = to
+  end
+
+  def date_range
+    if !!from && !!to
+      { "DateRange" => { "Start" => from, "End" => to } }
+    else
+      { :content! => '' }
+    end
   end
 
   def header
@@ -23,12 +34,7 @@ class Epics::HAC < Epics::GenericRequest
         "OrderDetails" => {
           "OrderType" => "HAC",
           "OrderAttribute" => "DZHNN",
-          "StandardOrderParams" => {
-            "DateRange" => {
-              "Start" => from,
-              "End" => to
-            }
-          }
+          "StandardOrderParams" => date_range
         },
         "BankPubKeyDigests" => {
           "Authentication" => {

--- a/spec/orders/hac_spec.rb
+++ b/spec/orders/hac_spec.rb
@@ -1,11 +1,39 @@
 RSpec.describe Epics::HAC do
-
   let(:client) { Epics::Client.new( File.open(File.join( File.dirname(__FILE__), '..', 'fixtures', 'SIZBN001.key')), 'secret' , 'https://194.180.18.30/ebicsweb/ebicsweb', 'SIZBN001', 'EBIX', 'EBICS') }
 
-  subject { described_class.new(client, "2014-09-01", "2014-09-30") }
+  context 'with date range' do
+    subject(:order) { described_class.new(client, "2014-09-01", "2014-09-30") }
 
-  describe '#to_xml' do
-    specify { expect(subject.to_xml).to be_a_valid_ebics_doc }
+    describe '#to_xml' do
+      specify { expect(order.to_xml).to be_a_valid_ebics_doc }
+
+      it 'does includes a date range as standard order parameter' do
+        expect(order.to_xml).to include('<StandardOrderParams><DateRange><Start>2014-09-01</Start><End>2014-09-30</End></DateRange></StandardOrderParams>')
+      end
+    end
+
+    describe '#to_receipt_xml' do
+      before { order.transaction_id = SecureRandom.hex(16) }
+
+      specify { expect(order.to_receipt_xml).to be_a_valid_ebics_doc }
+    end
   end
 
+  context 'without date range' do
+    subject(:order) { described_class.new(client) }
+
+    describe '#to_xml' do
+      specify { expect(order.to_xml).to be_a_valid_ebics_doc }
+
+      it 'does not include a standard order parameter' do
+        expect(order.to_xml).to include('<StandardOrderParams/>')
+      end
+    end
+
+    describe '#to_receipt_xml' do
+      before { order.transaction_id = SecureRandom.hex(16) }
+
+      specify { expect(order.to_receipt_xml).to be_a_valid_ebics_doc }
+    end
+  end
 end


### PR DESCRIPTION
Date ranges should only be provided if more than one system is fetching data or you need to re-fetch any records