### PR TITLE
fix missing order_id in upload requests

### DIFF
--- a/lib/epics/client.rb
+++ b/lib/epics/client.rb
@@ -202,7 +202,7 @@ class Epics::Client
 
     res = post(url, order.to_transfer_xml).body
 
-    return res.transaction_id, [res.order_id, order_id].detect { |id| id.to_s.size.positive? }
+    return res.transaction_id, [res.order_id, order_id].detect { |id| id.to_s.chars.any? }
   end
 
   def download(order_type, *args)

--- a/lib/epics/client.rb
+++ b/lib/epics/client.rb
@@ -198,9 +198,11 @@ class Epics::Client
     res = post(url, order.to_xml).body
     order.transaction_id = res.transaction_id
 
+    order_id = res.order_id
+
     res = post(url, order.to_transfer_xml).body
 
-    return res.transaction_id, res.order_id
+    return res.transaction_id, [res.order_id, order_id].detect { |id| id.to_s.size.positive? }
   end
 
   def download(order_type, *args)

--- a/spec/middleware/parse_ebics_spec.rb
+++ b/spec/middleware/parse_ebics_spec.rb
@@ -2,12 +2,12 @@ RSpec.describe Epics::ParseEbics do
 
   subject do
     Faraday.new do |builder|
+      builder.use Epics::ParseEbics
       builder.adapter :test, Faraday::Adapter::Test::Stubs.new do |stub|
         stub.post('/business_nok') {[ 200, {}, File.read( File.join( File.dirname(__FILE__), '..', 'fixtures', 'xml', 'ebics_business_nok.xml') )  ]}
         stub.post('/technical_nok') {[ 200, {}, File.read( File.join( File.dirname(__FILE__), '..', 'fixtures', 'xml', 'ebics_technical_nok.xml') )  ]}
         stub.post('/ok') {[ 200, {}, File.read( File.join( File.dirname(__FILE__), '..', 'fixtures', 'xml', 'hpb_response_ebics_ns.xml') )  ]}
       end
-      builder.use Epics::ParseEbics
     end
   end
 


### PR DESCRIPTION
fighting a case where the returned `order_id` happened to be an empty string for some accounts. this happened because the second response was missing the corresponding information in the response, we try to gracefully fetch it also from the first response and return the one we found last (although they should match anyways)