### PR TITLE
Fixing ContentType issue

### DIFF
--- a/lib/epics/middleware/xmlsig.rb
+++ b/lib/epics/middleware/xmlsig.rb
@@ -6,11 +6,12 @@ class Epics::XMLSIG < Faraday::Middleware
   end
 
   def call(env)
-    @signer = Epics::Signer.new(@client, env["body"])
+    @signer = Epics::Signer.new(@client, env['body'])
     @signer.digest!
     @signer.sign!
 
-    env["body"] = @signer.doc.to_xml(save_with: Nokogiri::XML::Node::SaveOptions::AS_XML)
+    env.request_headers['Content-Type']= ''
+    env['body'] = @signer.doc.to_xml(save_with: Nokogiri::XML::Node::SaveOptions::AS_XML)
 
     @app.call(env)
   end


### PR DESCRIPTION
some ebics servers seems to have problems with the content type set, so we’re removing it. seems nonbreaking for all other servers we have in use.