### PR TITLE
obtain all allowed order types of the customer

### DIFF
--- a/lib/epics/client.rb
+++ b/lib/epics/client.rb
@@ -55,6 +55,10 @@ class Epics::Client
     @bic ||= (self.HTD; @bic)
   end
 
+  def order_types
+    @order_types ||= (self.HTD; @order_types)
+  end
+
   def self.setup(passphrase, url, host_id, user_id, partner_id, keysize = 2048)
     client = new(nil, passphrase, url, host_id, user_id, partner_id)
     client.keys = %w(A006 X002 E002).each_with_object({}) do |type, memo|
@@ -165,9 +169,10 @@ class Epics::Client
 
   def HTD
     Nokogiri::XML(download(Epics::HTD)).tap do |htd|
-      @iban ||= htd.at_xpath("//xmlns:AccountNumber[@international='true']", xmlns: "urn:org:ebics:H004").text
-      @bic  ||= htd.at_xpath("//xmlns:BankCode[@international='true']", xmlns: "urn:org:ebics:H004").text
-      @name ||= htd.at_xpath("//xmlns:Name", xmlns: "urn:org:ebics:H004").text
+      @iban        ||= htd.at_xpath("//xmlns:AccountNumber[@international='true']", xmlns: "urn:org:ebics:H004").text
+      @bic         ||= htd.at_xpath("//xmlns:BankCode[@international='true']", xmlns: "urn:org:ebics:H004").text
+      @name        ||= htd.at_xpath("//xmlns:Name", xmlns: "urn:org:ebics:H004").text
+      @order_types ||= htd.search("//xmlns:OrderTypes", xmlns: "urn:org:ebics:H004").map{|o| o.content.split(/\s/) }.delete_if{|o| o == ""}.flatten
     end.to_xml
   end
 

--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -82,6 +82,16 @@ RSpec.describe Epics::Client do
     end
   end
 
+  describe '#order_types' do
+    before do
+      allow(subject).to receive(:download).and_return( File.read(File.join(File.dirname(__FILE__), 'fixtures', 'xml', 'htd_order_data.xml')))
+    end
+
+    it 'extracts the accessible order types of a subscriber' do
+      expect(subject.order_types).to match_array(%w(PTK HPD HTD STA HVD HPB HAA HVT HVU HVZ INI SPR PUB HIA HCA HSA HVE HVS CCS CCT CD1 CDD))
+    end
+  end
+
   describe '#HPB' do
     let(:e_key) do
       Epics::Key.new(OpenSSL::PKey::RSA.new(File.read(File.join(File.dirname(__FILE__), 'fixtures', 'bank_e.pem'))))
@@ -167,6 +177,10 @@ RSpec.describe Epics::Client do
 
     it 'sets @name' do
       expect { subject.HTD }.to change { subject.instance_variable_get("@name") }
+    end
+
+    it 'sets @order_types' do
+      expect { subject.HTD }.to change { subject.instance_variable_get("@order_types") }
     end
   end
 


### PR DESCRIPTION
Adds a convenience accessor (`#order_types`) to accessible order types by parsing the `HTD` response, same as we’re already doing for IBAN and name.

The result differs somewhat from the `HAA` response but includes every order types returned there too. 