### PR TITLE
Update nokogiri and rubyzip dependency

### DIFF
--- a/epics.gemspec
+++ b/epics.gemspec
@@ -42,11 +42,11 @@ Gem::Specification.new do |spec|
   if RUBY_VERSION < '2.1'
     spec.add_dependency "nokogiri", '< 1.7.0'
   else
-    spec.add_dependency "nokogiri"
+    spec.add_dependency "nokogiri", "~>1.8.2"
   end
 
   spec.add_dependency "faraday"
-  spec.add_dependency "rubyzip", ">= 1.0.0"
+  spec.add_dependency "rubyzip", ">= 1.2.1"
 
   spec.add_development_dependency "bundler", ">= 1.6.2"
   spec.add_development_dependency "rake", "~> 10.0"


### PR DESCRIPTION
rubyzip was already released a year ago so I thought it is safe to update, too. 
nokogiri is the mandatory update. 