### PR TITLE
Specify the CDB command for B2B direct debits.

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Communication Standard).
 
 The client supports the complete initialization process comprising INI, HIA and HPB including the
 INI letter generation. It offers support for the most common download and upload order types
-(STA HAA HTD HPD PTK HAC HKD C52 C53 C54 CD1 CDD CCT VMK B2B).
+(STA HAA HTD HPD PTK HAC HKD C52 C53 C54 CD1 CDB CDD CCT VMK).
 
 
 ## Installation
@@ -166,6 +166,7 @@ puts e.STA('2014-09-01', '2014-09-11')
 ### Uploads
 
 * CD1 (Uploads a SEPA Direct Debit document of type COR1)
+* CDB (Uploads a SEPA Direct Debit document of type B2B)
 * CDD (Uploads a SEPA Direct Debit document of type CORE)
 * CCT (Uploads a SEPA Credit document)
 * ... more coming soon

--- a/epics.gemspec
+++ b/epics.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
       STA HAA HTD HPD PKT HAC HKD C52 C53 C54
 
     And the following upload orders:
-      CD1 CDD CCT B2B CDS CCS CDZ
+      CD1 CDD CCT CDB CDS CCS CDZ
   description
 
   spec.homepage      = "https://github.com/railslove/epics"

--- a/lib/epics/client.rb
+++ b/lib/epics/client.rb
@@ -127,6 +127,10 @@ class Epics::Client
     upload(Epics::CD1, document)
   end
 
+  def CDB(document)
+    upload(Epics::CDB, document)
+  end
+
   def CDD(document)
     upload(Epics::CDD, document)
   end

--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -88,7 +88,7 @@ RSpec.describe Epics::Client do
     end
 
     it 'extracts the accessible order types of a subscriber' do
-      expect(subject.order_types).to match_array(%w(PTK HPD HTD STA HVD HPB HAA HVT HVU HVZ INI SPR PUB HIA HCA HSA HVE HVS CCS CCT CD1 CDD))
+      expect(subject.order_types).to match_array(%w(PTK HPD HTD STA HVD HPB HAA HVT HVU HVZ INI SPR PUB HIA HCA HSA HVE HVS CCS CCT CD1 CDB CDD))
     end
   end
 
@@ -128,6 +128,21 @@ RSpec.describe Epics::Client do
       it { expect(subject.keys["SIZBN001.E002"].public_digest).to eq(e_key.public_digest) }
       it { expect(subject.keys["SIZBN001.X002"].public_digest).to eq(e_key.public_digest) }
     end
+  end
+
+
+  describe '#CDB' do
+    let(:cdb_document) { File.read(File.join(File.dirname(__FILE__), 'fixtures', 'xml', 'cdb.xml')) }
+    before do
+      stub_request(:post, "https://194.180.18.30/ebicsweb/ebicsweb")
+        .with(:body => %r[<TransactionPhase>Initialisation</TransactionPhase>])
+        .to_return(status: 200, body: File.read(File.join(File.dirname(__FILE__), 'fixtures', 'xml', 'cdb_init_response.xml')))
+      stub_request(:post, "https://194.180.18.30/ebicsweb/ebicsweb")
+        .with(:body => %r[<TransactionPhase>Transfer</TransactionPhase>])
+        .to_return(status: 200, body: File.read(File.join(File.dirname(__FILE__), 'fixtures', 'xml', 'cdb_transfer_response.xml')))
+    end
+
+    it { expect(subject.CDB(cdb_document)).to eq(["387B7BE88FE33B0F4B60AC64A63F18E2","N00L"]) }
   end
 
   describe '#CD1' do

--- a/spec/fixtures/xml/cdb.xml
+++ b/spec/fixtures/xml/cdb.xml
@@ -1,0 +1,85 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Document xmlns="urn:iso:std:iso:20022:tech:xsd:pain.008.003.02" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:iso:std:iso:20022:tech:xsd:pain.008.003.02 pain.008.003.02.xsd">
+  <CstmrDrctDbtInitn>
+    <GrpHdr>
+      <MsgId>1434018161</MsgId>
+      <CreDtTm>2015-06-11T12:22:41+02:00</CreDtTm>
+      <NbOfTxs>1</NbOfTxs>
+      <CtrlSum>1.12</CtrlSum>
+      <InitgPty>
+        <Nm>Max Musterman</Nm>
+      </InitgPty>
+    </GrpHdr>
+    <PmtInf>
+      <PmtInfId>1434018161/1</PmtInfId>
+      <PmtMtd>DD</PmtMtd>
+      <BtchBookg>true</BtchBookg>
+      <NbOfTxs>1</NbOfTxs>
+      <CtrlSum>1.12</CtrlSum>
+      <PmtTpInf>
+        <SvcLvl>
+          <Cd>SEPA</Cd>
+        </SvcLvl>
+        <LclInstrm>
+          <Cd>B2B</Cd>
+        </LclInstrm>
+        <SeqTp>RCUR</SeqTp>
+      </PmtTpInf>
+      <ReqdColltnDt>2015-06-15</ReqdColltnDt>
+      <Cdtr>
+        <Nm>Max Mustermann</Nm>
+      </Cdtr>
+      <CdtrAcct>
+        <Id>
+          <IBAN>DE89370400440532013000</IBAN>
+        </Id>
+      </CdtrAcct>
+      <CdtrAgt>
+        <FinInstnId>
+          <BIC>COBADEFFXXX</BIC>
+        </FinInstnId>
+      </CdtrAgt>
+      <ChrgBr>SLEV</ChrgBr>
+      <CdtrSchmeId>
+        <Id>
+          <PrvtId>
+            <Othr>
+              <Id>DE98ZZZ09999999999</Id>
+              <SchmeNm>
+                <Prtry>SEPA</Prtry>
+              </SchmeNm>
+            </Othr>
+          </PrvtId>
+        </Id>
+      </CdtrSchmeId>
+      <DrctDbtTxInf>
+        <PmtId>
+          <EndToEndId>86</EndToEndId>
+        </PmtId>
+        <InstdAmt Ccy="EUR">1.12</InstdAmt>
+        <DrctDbtTx>
+          <MndtRltdInf>
+            <MndtId>M123123</MndtId>
+            <DtOfSgntr>2015-06-01</DtOfSgntr>
+          </MndtRltdInf>
+        </DrctDbtTx>
+        <DbtrAgt>
+          <FinInstnId>
+            <BIC>BKAUATWW</BIC>
+          </FinInstnId>
+        </DbtrAgt>
+        <Dbtr>
+          <Nm>Maria Musterfrau</Nm>
+        </Dbtr>
+        <DbtrAcct>
+          <Id>
+            <IBAN>AT611904300234573201</IBAN>
+          </Id>
+        </DbtrAcct>
+        <RmtInf>
+          <Ustrd>Purpose</Ustrd>
+        </RmtInf>
+      </DrctDbtTxInf>
+    </PmtInf>
+  </CstmrDrctDbtInitn>
+</Document>

--- a/spec/fixtures/xml/cdb_init_response.xml
+++ b/spec/fixtures/xml/cdb_init_response.xml
@@ -1,0 +1,31 @@
+<ebicsResponse Revision="1" Version="H004" xsi:schemaLocation="urn:org:ebics:H004 ebics_response_H004.xsd" xmlns="urn:org:ebics:H004" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:ds="http://www.w3.org/2000/09/xmldsig#">
+  <header authenticate="true">
+    <static>
+      <TransactionID>387B7BE88FE33B0F4B60AC64A63F18E2</TransactionID>
+    </static>
+    <mutable>
+      <TransactionPhase>Initialisation</TransactionPhase>
+      <OrderID>N00L</OrderID>
+      <ReturnCode>000000</ReturnCode>
+      <ReportText>[EBICS_OK] OK</ReportText>
+    </mutable>
+  </header>
+  <AuthSignature>
+    <ds:SignedInfo>
+      <ds:CanonicalizationMethod Algorithm="http://www.w3.org/TR/2001/REC-xml-c14n-20010315" />
+      <ds:SignatureMethod Algorithm="http://www.w3.org/2001/04/xmldsig-more#rsa-sha256" />
+      <ds:Reference URI="#xpointer(//*[@authenticate='true'])">
+        <ds:Transforms>
+          <ds:Transform Algorithm="http://www.w3.org/TR/2001/REC-xml-c14n-20010315" />
+        </ds:Transforms>
+        <ds:DigestMethod Algorithm="http://www.w3.org/2001/04/xmlenc#sha256" />
+        <ds:DigestValue>hSf/fZURBW6ihKUUZDMRpqc3kloVZZRjw+DTBxjS7AM=</ds:DigestValue>
+      </ds:Reference>
+    </ds:SignedInfo>
+    <ds:SignatureValue>IFHzo6jch33gA0Ovxh4VWtAwJOJRdxffMy7Yi+a+UUWPM/ekNqcewCWxgjbcWgD/LiH6eQc58iKcZdNKpaKfplQ09CJi1VBry5sd97i4tlCAhoM95JTrJjp2O6PhswAo+a6dpuXmA11u57BK0/nHENMIh4+Qw3aGszn21Ft8qwo=</ds:SignatureValue>
+  </AuthSignature>
+  <body>
+    <ReturnCode authenticate="true">000000</ReturnCode>
+    <TimestampBankParameter authenticate="true">2007-10-19T14:58:39.467Z</TimestampBankParameter>
+  </body>
+</ebicsResponse>

--- a/spec/fixtures/xml/cdb_transfer_response.xml
+++ b/spec/fixtures/xml/cdb_transfer_response.xml
@@ -1,0 +1,32 @@
+<ebicsResponse Revision="1" Version="H004" xsi:schemaLocation="urn:org:ebics:H004 ebics_response_H004.xsd" xmlns="urn:org:ebics:H004" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:ds="http://www.w3.org/2000/09/xmldsig#">
+  <header authenticate="true">
+    <static>
+      <TransactionID>387B7BE88FE33B0F4B60AC64A63F18E2</TransactionID>
+    </static>
+    <mutable>
+      <TransactionPhase>Transfer</TransactionPhase>
+      <SegmentNumber lastSegment="true">1</SegmentNumber>
+      <OrderID>N00L</OrderID>
+      <ReturnCode>000000</ReturnCode>
+      <ReportText>[EBICS_OK] OK</ReportText>
+    </mutable>
+  </header>
+  <AuthSignature>
+    <ds:SignedInfo>
+      <ds:CanonicalizationMethod Algorithm="http://www.w3.org/TR/2001/REC-xml-c14n-20010315" />
+      <ds:SignatureMethod Algorithm="http://www.w3.org/2001/04/xmldsig-more#rsa-sha256" />
+      <ds:Reference URI="#xpointer(//*[@authenticate='true'])">
+        <ds:Transforms>
+          <ds:Transform Algorithm="http://www.w3.org/TR/2001/REC-xml-c14n-20010315" />
+        </ds:Transforms>
+        <ds:DigestMethod Algorithm="http://www.w3.org/2001/04/xmlenc#sha256" />
+        <ds:DigestValue></ds:DigestValue>
+      </ds:Reference>
+    </ds:SignedInfo>
+    <ds:SignatureValue></ds:SignatureValue>
+  </AuthSignature>
+  <body>
+    <ReturnCode authenticate="true">000000</ReturnCode>
+    <TimestampBankParameter authenticate="true">2007-10-19T14:58:39.467Z</TimestampBankParameter>
+  </body>
+</ebicsResponse>

--- a/spec/fixtures/xml/htd_order_data.xml
+++ b/spec/fixtures/xml/htd_order_data.xml
@@ -134,6 +134,12 @@
       <NumSigRequired>1</NumSigRequired>
     </OrderInfo>
     <OrderInfo>
+      <OrderType>CDB</OrderType>
+      <TransferType>Upload</TransferType>
+      <Description>CDB</Description>
+      <NumSigRequired>1</NumSigRequired>
+    </OrderInfo>
+    <OrderInfo>
       <OrderType>CDD</OrderType>
       <TransferType>Upload</TransferType>
       <Description>Direct Debit Initiation</Description>
@@ -147,7 +153,7 @@
       <OrderTypes>PTK HPD HTD STA HVD HPB HAA HVT HVU HVZ</OrderTypes>
     </Permission>
     <Permission AuthorisationLevel="E">
-      <OrderTypes>INI SPR PUB HIA HCA HSA HVE HVS CCS CCT CD1 CDD</OrderTypes>
+      <OrderTypes>INI SPR PUB HIA HCA HSA HVE HVS CCS CCT CD1 CDB CDD</OrderTypes>
     </Permission>
   </UserInfo>
 </HTDResponseOrderData>

--- a/spec/orders/cdb_spec.rb
+++ b/spec/orders/cdb_spec.rb
@@ -1,7 +1,7 @@
 RSpec.describe Epics::CDB do
 
   let(:client) { Epics::Client.new( File.open(File.join( File.dirname(__FILE__), '..', 'fixtures', 'SIZBN001.key')), 'secret' , 'https://194.180.18.30/ebicsweb/ebicsweb', 'SIZBN001', 'EBIX', 'EBICS') }
-  let(:document) { File.read( File.join( File.dirname(__FILE__), '..', 'fixtures', 'xml', 'cd1.xml') ) }
+  let(:document) { File.read( File.join( File.dirname(__FILE__), '..', 'fixtures', 'xml', 'cdb.xml') ) }
   subject { described_class.new(client, document) }
 
   describe '#to_xml' do


### PR DESCRIPTION
Hi,

some days ago, https://github.com/railslove/epics/pull/19 was closed, since https://github.com/railslove/epics/commit/d8a087de6d279054101ef3f1ac4e1b43416bb69e already implemented `CDB`. 

This PR adds specific fixtures for the `CDB` command. Also it exposes `Epics::Client.CDB(doc)` and annotates it in the readme and the gemspec. 