### PR TITLE
do not mask transport client errors behind `Epics::Error::UnknownError`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+### 1.8.1
+- [BUGFIX] Remove masking of transport client errors
+
 ### 1.8.0
 
 - [HOUSEKEEPING] updates faraday and rubyzip

--- a/lib/epics/error.rb
+++ b/lib/epics/error.rb
@@ -334,4 +334,3 @@ class Epics::Error < StandardError
   end
 
 end
-class Epics::Error::UnknownError < StandardError; end

--- a/lib/epics/middleware/parse_ebics.rb
+++ b/lib/epics/middleware/parse_ebics.rb
@@ -14,7 +14,5 @@ class Epics::ParseEbics < Faraday::Middleware
     end
   rescue Epics::Error::TechnicalError, Epics::Error::BusinessError
     raise # re-raise as otherwise they would be swallowed by the following rescue
-  rescue StandardError => e
-    raise Epics::Error::UnknownError, e
   end
 end

--- a/lib/epics/middleware/parse_ebics.rb
+++ b/lib/epics/middleware/parse_ebics.rb
@@ -9,10 +9,8 @@ class Epics::ParseEbics < Faraday::Middleware
   def call(env)
     @app.call(env).on_complete do |response|
       response.body = ::Epics::Response.new(@client, response.body)
-      raise Epics::Error::TechnicalError, response.body.technical_code if response.body.technical_error?
-      raise Epics::Error::BusinessError, response.body.business_code if response.body.business_error?
+      raise(Epics::Error::TechnicalError, response.body.technical_code) if response.body.technical_error?
+      raise(Epics::Error::BusinessError, response.body.business_code)   if response.body.business_error?
     end
-  rescue Epics::Error::TechnicalError, Epics::Error::BusinessError
-    raise # re-raise as otherwise they would be swallowed by the following rescue
   end
 end

--- a/lib/epics/version.rb
+++ b/lib/epics/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Epics
-  VERSION = '1.8.0'
+  VERSION = '1.8.1'
 end

--- a/spec/middleware/parse_ebics_spec.rb
+++ b/spec/middleware/parse_ebics_spec.rb
@@ -23,17 +23,13 @@ RSpec.describe Epics::ParseEbics do
     expect(subject.post('/ok').body).to be_kind_of(Epics::Response)
   end
 
-  it 'will handle a timeout with raising an Epics::Error::TechnicalError' do
-    expect { subject.post('/timeout') }.to raise_error(Epics::Error::UnknownError, 'timeout')
-  end
-
   context 'failures' do
-    it 'will handle a timeout with raising an Epics::Error::TechnicalError' do
-      expect { subject.post('/timeout') }.to raise_error(Epics::Error::UnknownError, 'timeout')
+    it 'will raise a timeout correctly' do
+      expect { subject.post('/timeout') }.to raise_error(Faraday::TimeoutError, 'timeout')
     end
 
-    it 'will handle a no connection error with raising an Epics::Error::TechnicalError' do
-      expect { subject.post('/no_connection') }.to raise_error(Epics::Error::UnknownError, 'peer has finished all lan parties and gone home')
+    it 'will properly raise non-epics errors' do
+      expect { subject.post('/no_connection') }.to raise_error(Faraday::ConnectionFailed, 'peer has finished all lan parties and gone home')
     end
   end
 end


### PR DESCRIPTION
Imho it's bad behavior to mask transport client errors behind another error class. 