### PR TITLE
Bump version to 2.0.0 and add notes to CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+### 2.0.0
+- [BUGFIX] Update CDZ to download data, not upload it
+- [BUGFIX] Support signature for keys later than 2048 bit
+- [HOUSEKEEPING] Open rubyzip dependency to allow newer versions and update it
+- [HOUSEKEEPING] Update supported ruby versions to 2.6+
+- [HOUSEKEEPING] Update faraday, nokogiri, and development dependencies
+- [HOUSEKEEPING] Remove JRuby test execution due to failing tests - needs to be re-added if required
+
 ### 1.8.1
 - [BUGFIX] Remove masking of transport client errors
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 - [HOUSEKEEPING] Update supported ruby versions to 2.6+
 - [HOUSEKEEPING] Update faraday, nokogiri, and development dependencies
 - [HOUSEKEEPING] Remove JRuby test execution due to failing tests - needs to be re-added if required
+- [ENHANCEMENT] Adds CRZ order type
+- [ENHANCEMENT] Make date period optional for CDZ order type
 
 ### 1.8.1
 - [BUGFIX] Remove masking of transport client errors

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ### 2.0.0
+- [BUGFIX] Add Openssl 3.0 support
 - [BUGFIX] Update CDZ to download data, not upload it
 - [BUGFIX] Support signature for keys later than 2048 bit
 - [HOUSEKEEPING] Open rubyzip dependency to allow newer versions and update it

--- a/README.md
+++ b/README.md
@@ -265,4 +265,4 @@ Railslove has a [Contributor License Agreement (CLA)](https://github.com/railslo
 
 ---
 
-2014-2019 - built with love by [Railslove](http://railslove.com) and released under the [GNU LESSER GENERAL PUBLIC LICENSE](https://github.com/railslove/epics/blob/master/LICENSE.txt). We have built quite a number of FinTech products. If you need support we are happy to help. Please contact us at team@railslove.com.
+2014-2022 - built with love by [Railslove](http://railslove.com) and released under the [GNU LESSER GENERAL PUBLIC LICENSE](https://github.com/railslove/epics/blob/master/LICENSE.txt). We have built quite a number of FinTech products. If you need support we are happy to help. Please contact us at team@railslove.com.

--- a/epics.gemspec
+++ b/epics.gemspec
@@ -41,7 +41,7 @@ Gem::Specification.new do |spec|
   spec.post_install_message += "\e[32m" + ('*' * 60) + "\n\e[0m"
 
   spec.add_dependency 'faraday',  '>= 1.10.0'
-  spec.add_dependency 'nokogiri', '>= 1.13.7'
+  spec.add_dependency 'nokogiri', '>= 1.13.8'
   spec.add_dependency 'rubyzip',  '>= 2.3.2'
 
   spec.add_development_dependency 'bundler', '>= 1.17.3'

--- a/epics.gemspec
+++ b/epics.gemspec
@@ -41,7 +41,7 @@ Gem::Specification.new do |spec|
   spec.post_install_message += "\e[32m" + ('*' * 60) + "\n\e[0m"
 
   spec.add_dependency 'faraday',  '>= 1.10.0'
-  spec.add_dependency 'nokogiri', '>= 1.13.8'
+  spec.add_dependency 'nokogiri', '>= 1.13.9'
   spec.add_dependency 'rubyzip',  '>= 2.3.2'
 
   spec.add_development_dependency 'bundler', '>= 1.17.3'

--- a/epics.gemspec
+++ b/epics.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
       STA HAA HTD HPD PKT HAC HKD C52 C53 C54
 
     And the following upload orders:
-      CD1 CDD CCT CDB CDS CCS CDZ
+      CD1 CDD CCT CDB CDS CCS CDZ CRZ
   description
 
   spec.homepage      = 'https://github.com/railslove/epics'

--- a/epics.gemspec
+++ b/epics.gemspec
@@ -41,7 +41,7 @@ Gem::Specification.new do |spec|
   spec.post_install_message += "\e[32m" + ('*' * 60) + "\n\e[0m"
 
   spec.add_dependency 'faraday',  '>= 1.10.0'
-  spec.add_dependency 'nokogiri', '>= 1.13.6'
+  spec.add_dependency 'nokogiri', '>= 1.13.7'
   spec.add_dependency 'rubyzip',  '>= 2.3.2'
 
   spec.add_development_dependency 'bundler', '>= 1.17.3'

--- a/lib/epics/version.rb
+++ b/lib/epics/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Epics
-  VERSION = '1.8.1'
+  VERSION = '2.0.0'
 end


### PR DESCRIPTION
This updates the version to 2.0.0 because #105 was not 100% backwards compatible.

Additionally updated CHANGELOG and bumped nokogiri to the latest version to avoid even the latest bug in nokogiri (See https://nokogiri.org/CHANGELOG.html#1137-2022-07-12)