### PR TITLE
Add ruby 3.1 and 3.2 to the testing matrix

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -40,3 +40,19 @@ blocks:
             - bundle install
             - cache store
             - bundle exec rspec
+        - name: "3.1"
+          commands:
+            - checkout
+            - sem-version ruby 3.1
+            - cache restore
+            - bundle install
+            - cache store
+            - bundle exec rspec
+        - name: "3.2"
+          commands:
+            - checkout
+            - sem-version ruby 3.2
+            - cache restore
+            - bundle install
+            - cache store
+            - bundle exec rspec


### PR DESCRIPTION
I've noticed that the testing matrix only covers ruby up to 3.0. I've added 3.1 and 3.2 as well.
TBD: Removing older versions, as ruby 2.6 is EOL since last year and 2.7 will be EOL in April of this year.