### PR TITLE
Initialize RSA public key through ASN1 sequence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+### 2.1.1
+
+- [HOUSEKEEPING] update Bank public key initialization for OpenSSL 3
+
 ### 2.1.0
 
 - [HOUSEKEEPING] updates Nokogiri dependencies

--- a/lib/epics/client.rb
+++ b/lib/epics/client.rb
@@ -105,13 +105,11 @@ class Epics::Client
       modulus  = Base64.decode64(node.at_xpath(".//*[local-name() = 'Modulus']").content)
       exponent = Base64.decode64(node.at_xpath(".//*[local-name() = 'Exponent']").content)
 
-      bank   = OpenSSL::PKey::RSA.new
-      if bank.respond_to?(:set_key)
-        bank.set_key(OpenSSL::BN.new(modulus, 2), OpenSSL::BN.new(exponent, 2), nil)
-      else
-        bank.n = OpenSSL::BN.new(modulus, 2)
-        bank.e = OpenSSL::BN.new(exponent, 2)
-      end
+      sequence = []
+      sequence << OpenSSL::ASN1::Integer.new(OpenSSL::BN.new(modulus, 2))
+      sequence << OpenSSL::ASN1::Integer.new(OpenSSL::BN.new(exponent, 2))
+
+      bank = OpenSSL::PKey::RSA.new(OpenSSL::ASN1::Sequence(sequence).to_der)
 
       self.keys["#{host_id.upcase}.#{type}"] = Epics::Key.new(bank)
     end

--- a/lib/epics/version.rb
+++ b/lib/epics/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Epics
-  VERSION = '2.1.0'
+  VERSION = '2.1.1'
 end


### PR DESCRIPTION
Openssl 3 does not support set_key anymore, however the method still exists.
This change happened to make the key objects immutable.

However it also breaks the way the public key of the EBICS provider is initialized for now 

This addresses #138 