### PR TITLE
Fix order data encryption for OpenSSL 3

### DIFF
--- a/spec/generic_upload_spec.rb
+++ b/spec/generic_upload_spec.rb
@@ -46,4 +46,13 @@ RSpec.describe Epics::GenericUploadRequest do
     end
 
   end
+
+  describe '#encrypted_order_data' do
+    it 'returns the same data every time' do
+      data_1 = subject.encrypted_order_data
+      data_2 = subject.encrypted_order_data
+
+      expect(data_1).to eq(data_2)
+    end
+  end
 end


### PR DESCRIPTION
This is a fix for #142

After several hours of debugging, I've discovered that with OpenSSL 3, `Epics::GenericUploadRequest#encrypted_order_data` yields different values each time it is called which ultimately results in an XML file that our bank cannot process:
```ruby
require 'epics'

req = Epics::GenericUploadRequest.new(nil, 'test payload')
req.key = '0123456789abcdef'

OpenSSL::OPENSSL_LIBRARY_VERSION #=> "OpenSSL 3.0.9 30 May 2023"
req.encrypted_order_data #=> "Jr7i0oaXFT8ucCTQZ2r59iprComDkMDoahDQmUCqp2o="
req.encrypted_order_data #=> "9/KVbhwk8z4DSID4jsht677xQpCcawLNuF0Hg452JQM="
```
when running the same code with OpenSSL 1.1, the method yields identical results:
```ruby
OpenSSL::OPENSSL_LIBRARY_VERSION #=> "OpenSSL 1.1.1u  30 May 2023"
req.encrypted_order_data #=> "Jr7i0oaXFT8ucCTQZ2r59iprComDkMDoahDQmUCqp2o="
req.encrypted_order_data #=> "Jr7i0oaXFT8ucCTQZ2r59iprComDkMDoahDQmUCqp2o="
```

The reason for this seems be a change in the behavior of [`OpenSSL::Cipher#reset`](https://ruby-doc.org/3.2.2/exts/openssl/OpenSSL/Cipher.html#method-i-reset) which calls `EVP_CipherInit_ex(ctx, NULL, NULL, NULL, NULL, -1)` internally. More precisely, this happens when no initialization vector (IV) is given explicitly.

I've changed the code so that an empty IV is used (16 zero-bytes). This seems to match the OpenSSL 1.x behavior.

In addition, I've moved the `encrypt` call right after the cipher's initialization because according to the [docs](https://ruby-doc.org/3.2.2/exts/openssl/OpenSSL/Cipher.html#method-i-encrypt), it is required before calling `random_key`. The call to `encrypt` however doesn't need to be repeated as `reset` keeps the previous mode. (the -1 value to EVP_CipherInit_ex)

A real-world test with our bank (VR Bank) using CDB was successful with the proposed changes with both OpenSSL 1.1 and 3.