### PR TITLE
Support `X509Certificate` in INI and HIA request

### DIFF
--- a/lib/epics.rb
+++ b/lib/epics.rb
@@ -58,6 +58,7 @@ require "epics/hia"
 require "epics/ini"
 require "epics/hev"
 require "epics/signer"
+require "epics/x_509_certificate"
 require "epics/client"
 
 I18n.load_path += Dir[File.join(File.dirname(__FILE__), 'letter/locales', '*.yml')]

--- a/lib/epics/client.rb
+++ b/lib/epics/client.rb
@@ -1,12 +1,14 @@
 class Epics::Client
   extend Forwardable
 
-  attr_accessor :passphrase, :url, :host_id, :user_id, :partner_id, :keys, :keys_content, :locale, :product_name
+  attr_accessor :passphrase, :url, :host_id, :user_id, :partner_id, :keys, :keys_content, :locale, :product_name,
+                :x_509_certificate_a_content, :x_509_certificate_x_content, :x_509_certificate_e_content, :debug_mode
+
   attr_writer :iban, :bic, :name
-
+  
   def_delegators :connection, :post
-
-  def initialize(keys_content, passphrase, url, host_id, user_id, partner_id, locale: Epics::DEFAULT_LOCALE, product_name: Epics::DEFAULT_PRODUCT_NAME)
+  
+  def initialize(keys_content, passphrase, url, host_id, user_id, partner_id, options = {})
     self.keys_content = keys_content.respond_to?(:read) ? keys_content.read : keys_content if keys_content
     self.passphrase = passphrase
     self.keys = extract_keys if keys_content
@@ -14,8 +16,12 @@ class Epics::Client
     self.host_id    = host_id
     self.user_id    = user_id
     self.partner_id = partner_id
-    self.locale = locale
-    self.product_name = product_name
+    self.locale = options[:locale] || Epics::DEFAULT_LOCALE
+    self.product_name = options[:product_name] || Epics::DEFAULT_PRODUCT_NAME
+    self.debug_mode = !!options[:debug_mode]
+    self.x_509_certificate_a_content = options[:x_509_certificate_a_content]
+    self.x_509_certificate_x_content = options[:x_509_certificate_x_content]
+    self.x_509_certificate_e_content = options[:x_509_certificate_e_content]
   end
 
   def inspect
@@ -61,8 +67,8 @@ class Epics::Client
     @order_types ||= (self.HTD; @order_types)
   end
 
-  def self.setup(passphrase, url, host_id, user_id, partner_id, keysize = 2048)
-    client = new(nil, passphrase, url, host_id, user_id, partner_id)
+  def self.setup(passphrase, url, host_id, user_id, partner_id, keysize = 2048, options = {})
+    client = new(nil, passphrase, url, host_id, user_id, partner_id, options)
     client.keys = %w(A006 X002 E002).each_with_object({}) do |type, memo|
       memo[type] = Epics::Key.new( OpenSSL::PKey::RSA.generate(keysize) )
     end
@@ -274,6 +280,39 @@ class Epics::Client
     File.write(path, dump_keys)
   end
 
+  def x_509_certificate_a
+    return if x_509_certificate_a_content.nil? || x_509_certificate_a_content.empty?
+
+    Epics::X509Certificate.new(x_509_certificate_a_content)
+  end
+
+  def x_509_certificate_a_hash
+    cert = OpenSSL::X509::Certificate.new(x_509_certificate_a_content)
+    Digest::SHA256.hexdigest(cert.to_der).upcase
+  end
+
+  def x_509_certificate_x
+    return if x_509_certificate_x_content.nil? || x_509_certificate_x_content.empty?
+
+    Epics::X509Certificate.new(x_509_certificate_x_content)
+  end
+
+  def x_509_certificate_x_hash
+    cert = OpenSSL::X509::Certificate.new(x_509_certificate_x_content)
+    Digest::SHA256.hexdigest(cert.to_der).upcase
+  end
+
+  def x_509_certificate_e
+    return if x_509_certificate_e_content.nil? || x_509_certificate_e_content.empty?
+
+    Epics::X509Certificate.new(x_509_certificate_e_content)
+  end
+
+  def x_509_certificate_e_hash
+    cert = OpenSSL::X509::Certificate.new(x_509_certificate_e_content)
+    Digest::SHA256.hexdigest(cert.to_der).upcase
+  end
+
   private
 
   def upload(order_type, document)
@@ -313,7 +352,7 @@ class Epics::Client
       faraday.use Epics::XMLSIG, { client: self }
       faraday.use Epics::ParseEbics, { client: self}
       # faraday.use MyAdapter
-      # faraday.response :logger                  # log requests to STDOUT
+      faraday.response :logger, ::Logger.new(STDOUT), bodies: true if debug_mode # log requests/response to STDOUT
     end
   end
 

--- a/lib/epics/ini.rb
+++ b/lib/epics/ini.rb
@@ -23,9 +23,20 @@ class Epics::INI < Epics::GenericRequest
   end
 
   def key_signature
+    x_509_certificate_a = client.x_509_certificate_a
+
     Nokogiri::XML::Builder.new do |xml|
       xml.SignaturePubKeyOrderData('xmlns:ds' => 'http://www.w3.org/2000/09/xmldsig#', 'xmlns' => 'http://www.ebics.org/S001') {
         xml.SignaturePubKeyInfo {
+          if x_509_certificate_a
+            xml.send('ds:X509Data') do
+              xml.send('ds:X509IssuerSerial') do
+                xml.send('ds:X509IssuerName', x_509_certificate_a.issuer )
+                xml.send('ds:X509SerialNumber', x_509_certificate_a.version)
+              end
+              xml.send('ds:X509Certificate', x_509_certificate_a.data)
+            end
+          end
           xml.PubKeyValue {
             xml.send('ds:RSAKeyValue') {
               xml.send('ds:Modulus', Base64.strict_encode64([client.a.n].pack("H*")))

--- a/lib/epics/letter_renderer.rb
+++ b/lib/epics/letter_renderer.rb
@@ -1,7 +1,6 @@
 class Epics::LetterRenderer
   extend Forwardable
 
-  TEMPLATE_PATH = File.join(File.dirname(__FILE__), '../letter/', 'ini.erb')
   I18N_SCOPE = 'epics.letter'
 
   def initialize(client)
@@ -12,11 +11,22 @@ class Epics::LetterRenderer
     I18n.translate(key, **{ locale: @client.locale, scope: I18N_SCOPE }.merge(options))
   end
 
-  alias_method :t, :translate
+  alias t translate
 
-  def_delegators :@client, :host_id, :user_id, :partner_id, :a, :x, :e
+  def_delegators :@client, :host_id, :user_id, :partner_id, :a, :x, :e,
+                 :x_509_certificate_a_hash, :x_509_certificate_x_hash, :x_509_certificate_e_hash,
+                 :x_509_certificate_a_content, :x_509_certificate_x_content, :x_509_certificate_e_content
 
   def render(bankname)
-    ERB.new(File.read(TEMPLATE_PATH)).result(binding)
+    template_path = File.join(File.dirname(__FILE__), '../letter/', template_filename)
+    ERB.new(File.read(template_path)).result(binding)
+  end
+
+  def template_filename
+    use_x_509_certificate_template? ? 'ini_with_certs.erb' : 'ini.erb'
+  end
+
+  def use_x_509_certificate_template?
+    x_509_certificate_a_content && x_509_certificate_x_content && x_509_certificate_e_content
   end
 end

--- a/lib/epics/x_509_certificate.rb
+++ b/lib/epics/x_509_certificate.rb
@@ -1,0 +1,15 @@
+class Epics::X509Certificate
+  extend Forwardable
+
+  attr_reader :certificate
+
+  def_delegators :certificate, :issuer, :version
+
+  def initialize(crt_content)
+    @certificate = OpenSSL::X509::Certificate.new(crt_content)
+  end
+
+  def data
+    Base64.strict_encode64(@certificate.to_der)
+  end
+end

--- a/lib/letter/ini_with_certs.erb
+++ b/lib/letter/ini_with_certs.erb
@@ -1,0 +1,335 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en">
+<head>
+  <meta http-equiv="content-type" content="text/html; charset=utf-8">
+  <meta charset="UTF-8" />
+  <title>EBICS ini</title>
+  <style>
+      code {
+          font-size: 0.6rem;
+          overflow-wrap: break-word;
+      }
+      .code {
+          border-style: solid;
+          border-width: 1px;
+          padding: 8px;
+          background-color: azure;
+      }
+      .strong {
+          font-weight: bold;
+      }
+      h2 {
+          text-align: center;
+      }
+      td {
+          min-width: 150px;
+      }
+      table {
+          display: flex;
+          justify-content: center;
+      }
+      .column {
+          height: 100px;
+      }
+  </style>
+</head>
+<body>
+<div>
+  <h2><%= t('initialization_letter.a') %></h2>
+  <table>
+    <tr>
+      <td>
+        <div class="column">
+          <table>
+            <tr>
+              <td class="strong">
+                <%= t('date') %> :
+              </td>
+              <td>
+                <%= Date.today.strftime('%d.%m.%Y') %>
+              </td>
+            </tr>
+            <tr>
+              <td class="strong">
+                <%= t('time') %> :
+              </td>
+              <td>
+                <%= Time.now.strftime('%H:%M:%S') %>
+              </td>
+            </tr>
+            <tr>
+              <td class="strong">
+                <%= t('recipient') %> :
+              </td>
+              <td>
+                <%= bankname %>
+              </td>
+            </tr>
+          </table>
+        </div>
+      </td>
+      <td>
+        <div class="column">
+          <table>
+            <tr>
+              <td class="strong">
+                Host-ID :
+              </td>
+              <td>
+                <%= host_id %>
+              </td>
+            </tr>
+            <tr>
+              <td class="strong">
+                User-ID :
+              </td>
+              <td>
+                <%= user_id %>
+              </td>
+            </tr>
+            <tr>
+              <td class="strong">
+                Partner-ID :
+              </td>
+              <td>
+                <%= partner_id %>
+              </td>
+            </tr>
+            <tr>
+              <td class="strong">
+                <%= t('version') %> :
+              </td>
+              <td>
+                A006
+              </td>
+            </tr>
+          </table>
+        </div>
+      </td>
+    </tr>
+  </table>
+  <p><%= t('certificate') %> :</p>
+  <pre class="code"><code><%= x_509_certificate_a_content %></code></pre>
+  <p><%= t('hash') %> (SHA-256) :</p>
+  <p class="code"><code><%= x_509_certificate_a_hash.scan(/../).join(":") %></code></p>
+  <p><%= t('confirmation') %></p>
+  <br/>
+  <br/>
+  <br/>
+  <br/>
+  <table>
+    <tr>
+      <td>
+        _________________________
+      </td>
+      <td>
+        _________________________
+      </td>
+      <td>
+        _________________________
+      </td>
+    </tr>
+    <tr>
+      <td>
+        <%= t('issued_in') %>
+      </td>
+      <td>
+        <%= t('name') %>
+      </td>
+      <td>
+        <%= t('signature') %>
+      </td>
+    </tr>
+  </table>
+</div>
+<div style="page-break-after:always"></div>
+<div>
+  <h2><%= t('initialization_letter.x') %></h2>
+  <table>
+    <tr>
+      <td>
+        <div class="column">
+          <table>
+            <tr>
+              <td class="strong">
+                <%= t('date') %> :
+              </td>
+              <td>
+                <%= Date.today.strftime('%d.%m.%Y') %>
+              </td>
+            </tr>
+            <tr>
+              <td class="strong">
+                <%= t('time') %> :
+              </td>
+              <td>
+                <%= Time.now.strftime('%H:%M:%S') %>
+              </td>
+            </tr>
+            <tr>
+              <td class="strong">
+                <%= t('recipient') %> :
+              </td>
+              <td>
+                <%= bankname %>
+              </td>
+            </tr>
+          </table>
+        </div>
+      </td>
+      <td>
+        <div class="column">
+          <table>
+            <tr>
+              <td class="strong">
+                Host-ID :
+              </td>
+              <td>
+                <%= host_id %>
+              </td>
+            </tr>
+            <tr>
+              <td class="strong">
+                User-ID :
+              </td>
+              <td>
+                <%= user_id %>
+              </td>
+            </tr>
+            <tr>
+              <td class="strong">
+                Partner-ID :
+              </td>
+              <td>
+                <%= partner_id %>
+              </td>
+            </tr>
+            <tr>
+              <td class="strong">
+                <%= t('version') %> :
+              </td>
+              <td>
+                X002
+              </td>
+            </tr>
+          </table>
+        </div>
+      </td>
+    </tr>
+  </table>
+  <p><%= t('certificate') %> :</p>
+  <pre class="code"><code><%= x_509_certificate_x_content %></code></pre>
+  <p><%= t('hash') %> (SHA-256) :</p>
+  <p class="code"><code><%= x_509_certificate_x_hash.scan(/../).join(":") %></code></p>
+</div>
+<div style="page-break-after:always"></div>
+<div>
+  <h2><%= t('initialization_letter.e') %></h2>
+  <table>
+    <tr>
+      <td>
+        <div class="column">
+          <table>
+            <tr>
+              <td class="strong">
+                <%= t('date') %> :
+              </td>
+              <td>
+                <%= Date.today.strftime('%d.%m.%Y') %>
+              </td>
+            </tr>
+            <tr>
+              <td class="strong">
+                <%= t('time') %> :
+              </td>
+              <td>
+                <%= Time.now.strftime('%H:%M:%S') %>
+              </td>
+            </tr>
+            <tr>
+              <td class="strong">
+                <%= t('recipient') %> :
+              </td>
+              <td>
+                <%= bankname %>
+              </td>
+            </tr>
+          </table>
+        </div>
+      </td>
+      <td>
+        <div class="column">
+          <table>
+            <tr>
+              <td class="strong">
+                Host-ID :
+              </td>
+              <td>
+                <%= host_id %>
+              </td>
+            </tr>
+            <tr>
+              <td class="strong">
+                User-ID :
+              </td>
+              <td>
+                <%= user_id %>
+              </td>
+            </tr>
+            <tr>
+              <td class="strong">
+                Partner-ID :
+              </td>
+              <td>
+                <%= partner_id %>
+              </td>
+            </tr>
+            <tr>
+              <td class="strong">
+                <%= t('version') %> :
+              </td>
+              <td>
+                E002
+              </td>
+            </tr>
+          </table>
+        </div>
+      </td>
+    </tr>
+  </table>
+  <p><%= t('certificate') %> :</p>
+  <pre class="code"><code><%= x_509_certificate_e_content %></code></pre>
+  <p><%= t('hash') %> (SHA-256) :</p>
+  <p class="code"><code><%= x_509_certificate_e_hash.scan(/../).join(":") %></code></p>
+  <p><%= t('confirmation') %></p>
+  <br/>
+  <br/>
+  <br/>
+  <br/>
+  <table>
+    <tr>
+      <td>
+        _________________________
+      </td>
+      <td>
+        _________________________
+      </td>
+      <td>
+        _________________________
+      </td>
+    </tr>
+    <tr>
+      <td>
+        <%= t('issued_in') %>
+      </td>
+      <td>
+        <%= t('name') %>
+      </td>
+      <td>
+        <%= t('signature') %>
+      </td>
+    </tr>
+  </table>
+</div>
+</body>
+</html>

--- a/lib/letter/locales/de.yml
+++ b/lib/letter/locales/de.yml
@@ -9,6 +9,7 @@ de:
       exponent: Exponent
       modulus: Modulus
       hash: Hash
+      certificate: Zertifikat
       bit: '%{bit} Bit'
       issued_in: Ort/Datum
       name: Name/Firma

--- a/lib/letter/locales/en.yml
+++ b/lib/letter/locales/en.yml
@@ -9,6 +9,7 @@ en:
       exponent: Exponent
       modulus: Modulus
       hash: Hash
+      certificate: Certificate
       bit: '%{bit} Bit'
       issued_in: Location/Date
       name: Name/Company

--- a/lib/letter/locales/fr.yml
+++ b/lib/letter/locales/fr.yml
@@ -9,6 +9,7 @@ fr:
       exponent: Exponent
       modulus: Modulus
       hash: Hash
+      certificate: Certificat
       bit: '%{bit} Bit'
       issued_in: Lieu/Date
       name: Nom/Société

--- a/spec/orders/hia_spec.rb
+++ b/spec/orders/hia_spec.rb
@@ -1,5 +1,6 @@
 RSpec.describe Epics::HIA do
-  let(:client) { Epics::Client.new( File.open(File.join( File.dirname(__FILE__), '..', 'fixtures', 'SIZBN001.key')), 'secret' , 'https://194.180.18.30/ebicsweb/ebicsweb', 'SIZBN001', 'EBIX', 'EBICS') }
+  let(:client) { Epics::Client.new(key, 'secret', 'https://194.180.18.30/ebicsweb/ebicsweb', 'SIZBN001', 'EBIX', 'EBICS') }
+  let(:key) { File.read(File.join(File.dirname(__FILE__), '..', 'fixtures', 'SIZBN001.key')) }
 
   subject { described_class.new(client) }
 
@@ -7,24 +8,46 @@ RSpec.describe Epics::HIA do
     specify { expect(subject.to_xml).to be_a_valid_ebics_doc }
 
     describe 'validate against fixture' do
-      let(:hia) { Nokogiri::XML(File.read(File.join( File.dirname(__FILE__), '..', 'fixtures', 'xml', RUBY_ENGINE, 'hia.xml'))) }
+      let(:hia) do
+        Nokogiri::XML(File.read(File.join(File.dirname(__FILE__), '..', 'fixtures', 'xml', RUBY_ENGINE, 'hia.xml')))
+      end
 
-      it "will match exactly" do
+      it 'will match exactly' do
         expect(Nokogiri::XML(subject.to_xml)).to be_equivalent_to(hia)
       end
     end
   end
 
   describe '#order_data' do
-
     specify { expect(subject.order_data).to be_a_valid_ebics_doc }
 
     describe 'validate against fixture' do
+      let(:hia_request_order_data) do
+        Nokogiri::XML(File.read(File.join(File.dirname(__FILE__), '..', 'fixtures', 'xml',
+                                          'hia_request_order_data.xml')))
+      end
 
-      let(:hia_request_order_data) { Nokogiri::XML(File.read(File.join( File.dirname(__FILE__), '..', 'fixtures', 'xml', 'hia_request_order_data.xml'))) }
-
-      it "will match exactly" do
+      it 'will match exactly' do
         expect(Nokogiri::XML(subject.order_data)).to be_equivalent_to(hia_request_order_data)
+      end
+    end
+
+    context 'with x509 certificate' do
+      let(:client) do
+        client = Epics::Client.new(key, 'secret', 'https://194.180.18.30/ebicsweb/ebicsweb', 'SIZBN001', 'EBIX', 'EBICS')
+        client.x_509_certificate_x_content = generate_x_509_crt(client.x.key, distinguished_name)
+        client.x_509_certificate_e_content = generate_x_509_crt(client.e.key, distinguished_name)
+        client
+      end
+      let(:distinguished_name) { '/C=GB/O=TestOrg/CN=test.example.org' }
+
+      it 'includes x509 certificate' do
+        x_crt = Epics::X509Certificate.new(client.x_509_certificate_x_content)
+        e_crt = Epics::X509Certificate.new(client.x_509_certificate_e_content)
+        expect(subject.order_data).to include('<ds:X509IssuerName>/C=GB/O=TestOrg/CN=test.example.org</ds:X509IssuerName>')
+        expect(subject.order_data).to include('<ds:X509SerialNumber>2</ds:X509SerialNumber>')
+        expect(subject.order_data).to include("<ds:X509Certificate>#{x_crt.data}</ds:X509Certificate>")
+        expect(subject.order_data).to include("<ds:X509Certificate>#{e_crt.data}</ds:X509Certificate>")
       end
     end
   end

--- a/spec/orders/ini_spec.rb
+++ b/spec/orders/ini_spec.rb
@@ -1,7 +1,7 @@
 RSpec.describe Epics::INI do
-  let(:client) { Epics::Client.new( File.open(File.join( File.dirname(__FILE__), '..', 'fixtures', 'SIZBN001.key')), 'secret' , 'https://194.180.18.30/ebicsweb/ebicsweb', 'SIZBN001', 'EBIX', 'EBICS') }
-
-  before { allow(subject).to receive(:timestamp) { "2014-10-10T11:16:00Z" } }
+  let(:client) { Epics::Client.new(key, 'secret', 'https://194.180.18.30/ebicsweb/ebicsweb', 'SIZBN001', 'EBIX', 'EBICS') }
+  let(:key) { File.read(File.join(File.dirname(__FILE__), '..', 'fixtures', 'SIZBN001.key')) }
+  before { allow(subject).to receive(:timestamp) { '2014-10-10T11:16:00Z' } }
 
   subject { described_class.new(client) }
 
@@ -9,9 +9,11 @@ RSpec.describe Epics::INI do
     specify { expect(subject.to_xml).to be_a_valid_ebics_doc }
 
     describe 'validate against fixture' do
-      let(:signature_order_data) { Nokogiri::XML(File.read(File.join( File.dirname(__FILE__), '..', 'fixtures', 'xml', RUBY_ENGINE, 'ini.xml'))) }
+      let(:signature_order_data) do
+        Nokogiri::XML(File.read(File.join(File.dirname(__FILE__), '..', 'fixtures', 'xml', RUBY_ENGINE, 'ini.xml')))
+      end
 
-      it "will match exactly" do
+      it 'will match exactly' do
         expect(Nokogiri::XML(subject.to_xml)).to be_equivalent_to(signature_order_data)
       end
     end
@@ -21,11 +23,29 @@ RSpec.describe Epics::INI do
     specify { expect(subject.key_signature).to be_a_valid_ebics_doc }
 
     describe 'validate against fixture' do
+      let(:signature_order_data) do
+        Nokogiri::XML(File.read(File.join(File.dirname(__FILE__), '..', 'fixtures', 'xml',
+                                          'signature_pub_key_order_data.xml')))
+      end
 
-      let(:signature_order_data) { Nokogiri::XML(File.read(File.join( File.dirname(__FILE__), '..', 'fixtures', 'xml', 'signature_pub_key_order_data.xml'))) }
-
-      it "will match exactly" do
+      it 'will match exactly' do
         expect(Nokogiri::XML(subject.key_signature)).to be_equivalent_to(signature_order_data)
+      end
+    end
+
+    context 'with x509 certificate' do
+      let(:client) do
+        client = Epics::Client.new(key, 'secret', 'https://194.180.18.30/ebicsweb/ebicsweb', 'SIZBN001', 'EBIX', 'EBICS')
+        client.x_509_certificate_a_content = generate_x_509_crt(client.a.key, distinguished_name)
+        client
+      end
+      let(:distinguished_name) { '/C=GB/O=TestOrg/CN=test.example.org' }
+
+      it 'includes x509 certificate' do
+        a_crt = Epics::X509Certificate.new(client.x_509_certificate_a_content)
+        expect(subject.key_signature).to include('<ds:X509IssuerName>/C=GB/O=TestOrg/CN=test.example.org</ds:X509IssuerName>')
+        expect(subject.key_signature).to include('<ds:X509SerialNumber>2</ds:X509SerialNumber>')
+        expect(subject.key_signature).to include("<ds:X509Certificate>#{a_crt.data}</ds:X509Certificate>")
       end
     end
   end

--- a/spec/orders/x_509_certificate_spec.rb
+++ b/spec/orders/x_509_certificate_spec.rb
@@ -1,0 +1,26 @@
+RSpec.describe Epics::X509Certificate do
+  subject(:x_509_certificate) { described_class.new(crt_content) }
+
+  let(:key) { OpenSSL::PKey::RSA.new(2048) }
+  let(:crt_content) { generate_x_509_crt(key, distinguished_name) }
+  let(:distinguished_name) { '/C=GB/O=TestOrg/CN=test.example.org' }
+
+  describe '#issuer' do
+    it 'returns the issuer of the certificate' do
+      expect(x_509_certificate.issuer.to_s).to eq(distinguished_name)
+    end
+  end
+  
+  describe '#version' do
+    it 'returns the version of the certificate' do
+      expect(x_509_certificate.version).to eq(2)
+    end
+  end
+  
+  describe '#data' do
+    it 'returns the base64 encoded certificate data' do
+      expect(x_509_certificate.data).to start_with('MIIDDzCCAfegAwIBAgIBATANBgkqhkiG9w0BA')
+      expect(x_509_certificate.data).to end_with('==')
+    end
+  end
+end

--- a/spec/support/x_509_crt_generator.rb
+++ b/spec/support/x_509_crt_generator.rb
@@ -1,0 +1,22 @@
+def generate_x_509_crt(key, distinguished_name)
+  name = OpenSSL::X509::Name.parse(distinguished_name)
+
+  cert = OpenSSL::X509::Certificate.new
+  cert.version = 2
+  cert.serial = 1
+  cert.subject = name
+  cert.issuer = name
+  cert.public_key = key.public_key
+  cert.not_before = Time.now
+  cert.not_after = cert.not_before + 365 * 24 * 60 * 60
+
+  ef = OpenSSL::X509::ExtensionFactory.new
+  ef.subject_certificate = cert
+  ef.issuer_certificate = cert
+  cert.add_extension(ef.create_extension("basicConstraints", "CA:FALSE", true))
+  cert.add_extension(ef.create_extension("keyUsage", "digitalSignature,keyEncipherment,nonRepudiation", true))
+
+  cert.sign(key, OpenSSL::Digest::SHA256.new)
+
+  cert.to_pem
+end


### PR DESCRIPTION
This PR adds support for using x509 self-signed certificates in INI and HIA requests.
_Details_
- Enables the use of x509 self-signed certificates when handling INI and HIA requests.
- Updates the generation of `init_letter` to use certificate data instead of a,x and e keys.
- Adds support for passing a debug_mode: boolean option to client initialization, allowing easy logging of requests and responses for debugging purposes. When debug_mode is enabled, Faraday’s logger middleware is activated to output request and response bodies to STDOUT

_Impact_
- No breaking changes; existing workflows not using certificates remain unaffected.
- Users can now configure and use certificates for INI and HIA interactions as needed.