### PR TITLE
Fix for multi-segment issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 ### Unreleased
 
+## [2.12.0]
+
+### Fixed
+- Fixed multi-segment download handling for C53 and other order types
+- Transaction key is now properly cached from first segment and reused
+- Segments are combined before decryption (matching EBICS specification)
+- Added proper support for zero IV in AES-128-CBC decryption
+
+### Changed
+- Refactored download method to better handle multi-segment responses
+
 ### 2.11.0
 
 - [ENHANCEMENT] Added FUL order type (thanks to @scollon-pl)


### PR DESCRIPTION
## Problem
Multi-segment downloads (especially C53) were failing because segments were being decrypted individually instead of being combined first.

## Solution
This PR fixes the multi-segment download process to match EBICS specification:
1. Extract and decrypt transaction key from first segment only
2. Collect all segments as encrypted binary data (without individual decryption)
3. Combine all encrypted segments
4. Decrypt the combined data using the cached transaction key
5. Decompress the result

## Changes
- Added `order_data_binary` method to get raw encrypted segment data
- Modified `download` method to handle multi-segment responses correctly
- Added transaction key caching across segments
- Improved debug logging

## Testing
- Tested with C53 multi-segment downloads
- Verified backward compatibility with single-segment downloads
- All existing tests pass
